### PR TITLE
Spelling fix in documentation and code comments.

### DIFF
--- a/java/telehash-core/src/main/java/org/telehash/SeeHandler.java
+++ b/java/telehash-core/src/main/java/org/telehash/SeeHandler.java
@@ -51,7 +51,7 @@ public class SeeHandler implements TelexHandler {
 		            recvLine.setVisible(true);
 		            recvLine.getNeighbors().addAll(
 		            		switchHandler.nearTo(recvLine.getEnd(), switchHandler.getAddress()));
-		            switchHandler.nearTo(recvLine.getEnd(), recvLine.getAddress()); // injects this switch as hints into it's neighbors, fully seeded now
+		            switchHandler.nearTo(recvLine.getEnd(), recvLine.getAddress()); // injects this switch as hints into its neighbors, fully seeded now
 		        }
 		        
 		        Hash seeHash = Hash.of(seeAddr); 

--- a/java/telehash-core/templates/editor/Editor.javajet
+++ b/java/telehash-core/templates/editor/Editor.javajet
@@ -698,7 +698,7 @@ public class <%=genPackage.getEditorClassName()%>
 <%}%>
 
 	/**
-	 * Handles activation of the editor or it's associated views.
+	 * Handles activation of the editor or its associated views.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated

--- a/node.js/telehash.js
+++ b/node.js/telehash.js
@@ -471,7 +471,7 @@ Switch.prototype.onCommand_see = function(remoteipp, telex, line) {
             console.log(["\t\tVISIBLE ", remoteipp].join(""));
             line.visible=1;
             self.near_to(line.end, self.selfipp).map(function(x) { return line.neighbors[x]=1; });
-            self.near_to(line.end, remoteipp); // injects this switch as hints into it's neighbors, fully seeded now
+            self.near_to(line.end, remoteipp); // injects this switch as hints into its neighbors, fully seeded now
         }
         
         var seeippHash = new Hash(seeipp).toString(); 

--- a/notes.txt
+++ b/notes.txt
@@ -39,7 +39,7 @@ common utility patterns
 		configured shared authority, probably app-defined or selectable
 		custom protocol to authority to authenticate app on initialization (http or th)
 		have announcement signal signed by authority
-		dial the hash(es) that peers would be listening on sending your identifying signal and it's sig
+		dial the hash(es) that peers would be listening on sending your identifying signal and its sig
 			"itsme"="1.2.3.4:5678"
 			"itsme-sig"="60AD5A78..."
 	self-signed (trust is discovered and then remembered, like ssh/otr)
@@ -60,7 +60,7 @@ data structure thoughts
 	two root lists
 		writers
 			hashtable by cb as the key
-			each one contains details about a writer and it's last known state
+			each one contains details about a writer and its last known state
 		hashes
 			hashtable by sha1 hash as the key
 			contains what we know about this hash

--- a/org/proto.html
+++ b/org/proto.html
@@ -66,7 +66,7 @@ function flag(id)
 
 <h2>Switch</h2>
 <p>
-	Every TeleHash endpoint on the network is called a Switch, there is usually one per application.  It is identified by it's public IP:PORT, and placed within the DHT by the SHA1(IP:PORT). Switches communicate only by sending UDP packets to each other.
+	Every TeleHash endpoint on the network is called a Switch, there is usually one per application.  It is identified by its public IP:PORT, and placed within the DHT by the SHA1(IP:PORT). Switches communicate only by sending UDP packets to each other.
 
 <h2>Telex</h2>
 <p>
@@ -135,16 +135,16 @@ function flag(id)
 </blockquote>
 
 <h2>DHT (Kademlia)</h2>
-<p>For the specific details, learning more about <a href="http://en.wikipedia.org/wiki/Kademlia">Kademlia</a> is highly encouraged. Essentially, every Switch on the DHT is identified by a SHA1 hash, and it has a known distance between every other Switch that is the XOR of the two hashes.  Every Switch maintains a list of it's neighbors, some further from that, and a few from very far away (see "buckets" in the Kademlia paper), that it uses to recommend who else to connect to for someone querying a location on the DHT.
+<p>For the specific details, learning more about <a href="http://en.wikipedia.org/wiki/Kademlia">Kademlia</a> is highly encouraged. Essentially, every Switch on the DHT is identified by a SHA1 hash, and it has a known distance between every other Switch that is the XOR of the two hashes.  Every Switch maintains a list of its neighbors, some further from that, and a few from very far away (see "buckets" in the Kademlia paper), that it uses to recommend who else to connect to for someone querying a location on the DHT.
 
 <span class="flag" onclick="this.parentNode.nextSibling.className='out';this.style.display='none'"></span>
 <blockquote class="in">
 	<h4>Switch Identity</h4>
-	<p>Every Switch's location in the DHT is simply the SHA1 of it's public IP:PORT.</p>
+	<p>Every Switch's location in the DHT is simply the SHA1 of its public IP:PORT.</p>
 	<h4>Location Requests ("Dialing")</h4>
 	<p>The most common activity in TeleHash is that of looking for closer Switches to a given +end hash.  Any Telex that contains a +end should be responded to with a list of the closest known Switches to that +end.  This is called the .see command, the value is an array of IP:PORTs of other Switches. (needs more, send self if closest, send self to make visible, how many to return and how to prefer, etc)
 	<h4>Seeding</h4>
-	<p>Upon starting up the Switch must contact one or more other Switches from a default list, and from there "Dial" recursively Switches that are closer to it's own +end hash.  Once it can't find any closer it then maintains lines to those closest, filling in it's "buckets".
+	<p>Upon starting up the Switch must contact one or more other Switches from a default list, and from there "Dial" recursively Switches that are closer to its own +end hash.  Once it can't find any closer it then maintains lines to those closest, filling in its "buckets".
 </blockquote>
 
 <h2>Startup</h2>
@@ -152,7 +152,7 @@ function flag(id)
 	The very first thing any Switch needs to do upon starting is discover the public IP:PORT that it is known to the world as, and it does this by contacting a seed.  Seeds are a list of well known, public IP:PORTs, such as the current primary one "telehash.org:42424".  Every Telex sent/received should contain a _to header of the recipients IP:PORT, so a new Switch needs only trigger any response from the seed.  This can be done by sending: {"+end":"a9993e364706816aba3e25717850c26c9cd0d89d"} to the seed (or any sha1 hash as the value).  The response should contain a "_to":"1.2.3.4:5678" of the new Switch's public IP:PORT.  The new Switch now has a location within the global DHT of the hash value of SHA1("1.2.3.4:5678").
 
 <p>
-	Next, the new Switch needs to seed itself in the DHT.  It does this by sending it's hash to one or more seeds in order to discover other Switches closer to itself, and repeating this process until no closer Switches are returned.
+	Next, the new Switch needs to seed itself in the DHT.  It does this by sending its hash to one or more seeds in order to discover other Switches closer to itself, and repeating this process until no closer Switches are returned.
 
 <h2>NATs</h2>
 <p>A very common pattern that every Switch has to deal with is working through NATs.  This is accomplished using the already mentioned mechanisms of .tap commands and a signal called +pop, for ping-open-port.
@@ -170,7 +170,7 @@ function flag(id)
 	<p>
 	<p>Lexicon:
 	<ul><blockquote>
-	<li>		<big>Switch</big> - every TeleHash endpoint is called a Switch, one per app, it's GUID is formed from the SHA1 of it's IP:PORT
+	<li>		<big>Switch</big> - every TeleHash endpoint is called a Switch, one per app, its GUID is formed from the SHA1 of its IP:PORT
 	<li>		<big>Telex</big> - each UDP packet is a JSON object, contains any valid JSON and one or more Commands, Signals, or Headers
 	<li>		<big>+Signal</big> - A public broadcast "key":"value" pair, routed/relayed between Switches
 	<li>		<big>.Command</big> - An instruction sent from one Switch to another
@@ -286,7 +286,7 @@ function flag(id)
 
 	<p>The low level protocol is designed to be the absolute minimal to build connections and exchange notifications, all needs for peer trust, proxying, anonymizing, etc happen at a higher layer and outside of the basic protocol. The required headers/commands are a bare minimum at every step even if it creates some implementation headaches, every additional datum sent is an vector for introducing future trust or spoofing problems.
 
-	<p>Dampening is used to reduce congestion around any single Switch or group of them nearby when there is a lot of signals or listeners coming in around one or more Ends.  There are two strategies, one when all the traffic is to a single End, and another when it's just to one part of the ring (different but nearby Ends).  A Switch should not .see back to anyone the IP:PORT of any other Switch when it's _br is sufficiently out of sync with it (need to test to find an appropriate window here), this dampens general parts of the DHT when traffic might flow beyond any Switches desire or ability to respond to.  Secondarily, any Switch should return itself as the endpoint for any End that is the most popular one it is seeing (also need to test to find best time window to check popularity).
+	<p>Dampening is used to reduce congestion around any single Switch or group of them nearby when there is a lot of signals or listeners coming in around one or more Ends.  There are two strategies, one when all the traffic is to a single End, and another when it's just to one part of the ring (different but nearby Ends).  A Switch should not .see back to anyone the IP:PORT of any other Switch when its _br is sufficiently out of sync with it (need to test to find an appropriate window here), this dampens general parts of the DHT when traffic might flow beyond any Switches desire or ability to respond to.  Secondarily, any Switch should return itself as the endpoint for any End that is the most popular one it is seeing (also need to test to find best time window to check popularity).
 
 
 	<h2>Switch Implementations</h2>
@@ -300,9 +300,9 @@ function flag(id)
 
 	<p>Full Switches need to implement seeding, keeping lines open, a basic bucketing system that tracks active Switches at different distances from themselves.  A Full Switch needs to do basic duplicate detection, it should only process a unique set of signals at most once every 10 seconds (hash the sorted string sigs/values).
 
-	<p>The _br header is important to any long-lived Switch to prevent sudden flooding and to control bandwidth rates.  Every incoming Telex's raw byte size should be totaled for it's sender, and any outgoing Telex sent back to them should contain a _br header with the current total received from them.  The raw bytes sent out to any other Switch should also be tracked, so that the two can be compared.  If the bytes sent out grows to more than 10k over the last _br reported back from the recipient, no more should be sent until an updated _br is received.  This also works in reverse, if more than 10k is received beyond the last _br sent out, incoming Telexes can be dropped.  An artificially higher _br can always be sent to allow a bigger than 10k window.
+	<p>The _br header is important to any long-lived Switch to prevent sudden flooding and to control bandwidth rates.  Every incoming Telex's raw byte size should be totaled for its sender, and any outgoing Telex sent back to them should contain a _br header with the current total received from them.  The raw bytes sent out to any other Switch should also be tracked, so that the two can be compared.  If the bytes sent out grows to more than 10k over the last _br reported back from the recipient, no more should be sent until an updated _br is received.  This also works in reverse, if more than 10k is received beyond the last _br sent out, incoming Telexes can be dropped.  An artificially higher _br can always be sent to allow a bigger than 10k window.
 
-	<p>The ideology of headers/cmds/sigs is as such: A _header can be of any type and it's purpose is to convey information about that single instance of a Telex and the state of a connection between Switches, meant to only carry extra information about the exchange, metadata, it is never meant to be used by any application or persisted/relayed.  A .command also can have any type of value and it's intended to cause an action on the recipient involving it's value and optionally including any signals in the same telex, also never to be relayed/persisted, private between Switches and open for applications to use custom commands to talk directly to each other.  A signal is always a string value usually relating to or from an application and is always considered public, possibly persisted and relayed to other Switches, and should only be used to convey information that may be of interest to an unknown or more than one party, discovery/announcements.
+	<p>The ideology of headers/cmds/sigs is as such: A _header can be of any type and its purpose is to convey information about that single instance of a Telex and the state of a connection between Switches, meant to only carry extra information about the exchange, metadata, it is never meant to be used by any application or persisted/relayed.  A .command also can have any type of value and it's intended to cause an action on the recipient involving its value and optionally including any signals in the same telex, also never to be relayed/persisted, private between Switches and open for applications to use custom commands to talk directly to each other.  A signal is always a string value usually relating to or from an application and is always considered public, possibly persisted and relayed to other Switches, and should only be used to convey information that may be of interest to an unknown or more than one party, discovery/announcements.
 
 	<p>Only one .tap can be active between any two Switches at any time, and while it can have some complex filters internal to it, it is one unit.  This simplifies what a receiving Switch has to do to manage a bunch of active .taps.  If an app really needs more than one .tap active on some Switch at the same time, it can create another listener-only Switch to do that.
 

--- a/org/proto/congestion.md
+++ b/org/proto/congestion.md
@@ -5,6 +5,6 @@ When there's a lot of attention around one particular hash or address space (whe
 
 For taps the response is easy, any switch can just set a maximum threshold for the number of taps it wants to maintain, and can get fancy in trying to balance/detect common taps to ignore (normalize and hash the tap or the rules in a tap) if it wants.  When a switch that wants to tap that area fails, it should continue trying to tap other nearby switches until it moves far enough out/away on the ring to find capacity.
 
-For a large influx of end requests there are a number of possible strategies (that need to be explored and tested), including any given switch tracking how many times it returns a peer's IPP in a see response and never over-announcing it's presence, using br if becoming overwhelmed to announce to nearby neighbors that it's lower priority and shouldn't be announced, etc.
+For a large influx of end requests there are a number of possible strategies (that need to be explored and tested), including any given switch tracking how many times it returns a peer's IPP in a see response and never over-announcing its presence, using br if becoming overwhelmed to announce to nearby neighbors that it's lower priority and shouldn't be announced, etc.
 
 The goal is to KISS in handling these challenges by pushing the hot zones further out the ring, and therefore onto larger and larger swaths of switches.  Applications that need to operate around high density hashes may need to do extra work to tap larger areas as well.

--- a/org/proto/ipp.md
+++ b/org/proto/ipp.md
@@ -1,6 +1,6 @@
 IP:PORT (1.2.3.4:5678)
 ==================
 
-The public IP:PORT (IPP) is the primary identifier of any Switch, the SHA1 of it is it's location on the DHT.
+The public IP:PORT (IPP) is the primary identifier of any Switch, the SHA1 of it is its location on the DHT.
 
 The IPP also works identically for ipv6, but a switch is either ipv4 or ipv6 since the identifiers, buckets, and see responses are all IP specific.

--- a/org/proto/nats.md
+++ b/org/proto/nats.md
@@ -29,12 +29,12 @@ B->A (just forwarding due to the tap)
 	"_hop":1
 }
 
-A then knows to send a tiny hello Telex to C to open up a mapping from it's NAT to C:
+A then knows to send a tiny hello Telex to C to open up a mapping from its NAT to C:
 	{
 		"_to":"CIP:CPORT"
 	}
 
-Now C will have gotten that one since it had sent A a telex to open the mapping through it's NAT, and it can send any subsequent Telex it wants (either an end it's dialing, or a tap, or negotiate a direct connection for an app, etc).
+Now C will have gotten that one since it had sent A a telex to open the mapping through its NAT, and it can send any subsequent Telex it wants (either an end it's dialing, or a tap, or negotiate a direct connection for an app, etc).
 
 Switches can also negotiate internal network direct connections when they detect a peer they're trying to connect to is behind the same NAT (since the peer has the same IP but a different PORT).  Not defined here (yet) would be using Diffie–Hellman involving an external switch to swap each other's internal IP (10.x 172.x 192.x etc) to connect internally, without revealing that IP to the public network.
 

--- a/org/proto/switch.md
+++ b/org/proto/switch.md
@@ -1,4 +1,4 @@
 Switch
 ======
 
-A Switch is simply the name of any node on the DHT in TeleHash.  It's called a Switch as it's fundamental job on the DHT is to route Telex packets to the right recipients and perform any requests of the application it's running on behalf of.
+A Switch is simply the name of any node on the DHT in TeleHash.  It's called a Switch as its fundamental job on the DHT is to route Telex packets to the right recipients and perform any requests of the application it's running on behalf of.

--- a/org/proto/to.md
+++ b/org/proto/to.md
@@ -3,4 +3,4 @@ To (_to)
 
 When sending a Telex to any Switch it is highly recommended to send this name/value pair, where the value is the IPP of the recipient.
 
-Any Switch that is receiving packets behind a NAT will not know it's public IP:PORT until it receives this, and also needs to be able to detect if it changes.
+Any Switch that is receiving packets behind a NAT will not know its public IP:PORT until it receives this, and also needs to be able to detect if it changes.

--- a/perl/attic/dial.pl
+++ b/perl/attic/dial.pl
@@ -24,7 +24,7 @@ bind(SOCKET, $paddr)                          or die "bind: $!";
 $sel = IO::Select->new();
 $sel->add(\*SOCKET);
 
-# resolve our seed to it's ip:port
+# resolve our seed to its ip:port
 my($seedhost,$seedport) = split(":",$seed);
 my $seedip = gethostbyname($seedhost);
 my $seedipp = sprintf("%s:%d",inet_ntoa($seedip),$seedport);
@@ -113,7 +113,7 @@ sub telex
 	return $js;
 }
 
-# actually send a telex to it's writer
+# actually send a telex to its writer
 sub tsend
 {
 	my $j = shift;

--- a/perl/attic/listen.pl
+++ b/perl/attic/listen.pl
@@ -87,7 +87,7 @@ sub telex
 	return $js;
 }
 
-# actually send a telex to it's writer
+# actually send a telex to its writer
 sub tsend
 {
 	my $j = shift;

--- a/perl/attic/writer.pl
+++ b/perl/attic/writer.pl
@@ -25,7 +25,7 @@ bind(SOCKET, $paddr)                          or die "bind: $!";
 $sel = IO::Select->new();
 $sel->add(\*SOCKET);
 
-# resolve our seed to it's ip:port
+# resolve our seed to its ip:port
 my($seedhost,$seedport) = split(":",$seed);
 my $seedip = gethostbyname($seedhost);
 my $seedipp = sprintf("%s:%d",inet_ntoa($seedip),$seedport);
@@ -279,7 +279,7 @@ sub tnew
 	return $js;
 }
 
-# actually send a telex to it's writer
+# actually send a telex to its writer
 sub tsend
 {
 	my $j = shift;

--- a/perl/dial.pl
+++ b/perl/dial.pl
@@ -24,7 +24,7 @@ bind(SOCKET, $paddr)                          or die "bind: $!";
 $sel = IO::Select->new();
 $sel->add(\*SOCKET);
 
-# resolve our seed to it's ip:port
+# resolve our seed to its ip:port
 my($seedhost,$seedport) = split(":",$seed);
 my $seedip = gethostbyname($seedhost);
 my $seedipp = sprintf("%s:%d",inet_ntoa($seedip),$seedport);
@@ -111,7 +111,7 @@ sub telex
 	return $js;
 }
 
-# actually send a telex to it's IPP
+# actually send a telex to its IPP
 sub tsend
 {
 	my $j = shift;

--- a/perl/listen.pl
+++ b/perl/listen.pl
@@ -107,7 +107,7 @@ sub telex
 	return $js;
 }
 
-# actually send a telex to it's writer
+# actually send a telex to its writer
 sub tsend
 {
 	my $j = shift;

--- a/perl/switch.pl
+++ b/perl/switch.pl
@@ -32,7 +32,7 @@ $sel = IO::Select->new();
 $sel->add(\*SOCKET);
 $sel->add(\*STDIN);
 
-# resolve our seed to it's ip:port
+# resolve our seed to its ip:port
 my($seedhost,$seedport) = split(":",$seed);
 my $seedip = gethostbyname($seedhost);
 my $seedipp = sprintf("%s:%d",inet_ntoa($seedip),$seedport);
@@ -181,7 +181,7 @@ sub in_udp
 					printf STDERR "\t\tVISIBLE %s\n",$remoteipp;
 					$line->{visible}=1;
 					map {$line->{neighbors}->{$_}=1} near_to($line->{end},$selfipp); # load values into this switch's neighbors list, start from ourselves
-					near_to($line->{end},$remoteipp); # injects this switch as hints into it's neighbors, fully seeded now
+					near_to($line->{end},$remoteipp); # injects this switch as hints into its neighbors, fully seeded now
 				}
 				next if($master{sha1_hex($seeipp)}); # skip if we know them already
 				# XXX todo: if we're dialing we'd want to reach out to any of these closer to that $tap_end
@@ -419,7 +419,7 @@ sub tnew
 	return $js;
 }
 
-# actually send a telex to it's switch, add/track all line headers
+# actually send a telex to its switch, add/track all line headers
 sub tsend
 {
 	my $j = shift;

--- a/perl/ump.pl
+++ b/perl/ump.pl
@@ -12,7 +12,7 @@
 # 3. when a sig comes in, verify it
 # 4. +pop and try to connect back to it if good
 # 5. once connected, send our own verification and a challenge
-# 6. if challenge good, open another port and get it's public IP:PORT, +pop that back to the requestor
+# 6. if challenge good, open another port and get its public IP:PORT, +pop that back to the requestor
 # 7. once other port open/handshake, open udptunnel on it
 
 die("temp hack, plz run from the same dir as ./switch.pl and ./udptunnel") if(!-f "switch.pl" || !-f "udptunnel");

--- a/perl/wall_send.pl
+++ b/perl/wall_send.pl
@@ -26,7 +26,7 @@ bind(SOCKET, $paddr)                          or die "bind: $!";
 $sel = IO::Select->new();
 $sel->add(\*SOCKET);
 
-# resolve our seed to it's ip:port
+# resolve our seed to its ip:port
 my($seedhost,$seedport) = split(":",$seed);
 my $seedip = gethostbyname($seedhost);
 my $seedipp = sprintf("%s:%d",inet_ntoa($seedip),$seedport);
@@ -154,7 +154,7 @@ sub telex
 	return $js;
 }
 
-# actually send a telex to it's IPP
+# actually send a telex to its IPP
 sub tsend
 {
 	my $j = shift;

--- a/switchd/README
+++ b/switchd/README
@@ -1,6 +1,6 @@
 switchd - The easy way to get your app up and running with TeleHash
 
-Keeping a TeleHash Switch running takes some babysitting, all the timers to make sure Lines stay open, Dialing works, Listening is thorough, bandwidth usage is respected, and that peers are behaving appropriately.  Most applications need to have very careful control over their internal threading/event-handling models and the myriad of events needed to be a Switch adds a lot of complexity, so "switchd" is a simple localhost-based daemon that can do all that work in it's own process space, and provide some simple local API calls that are much more easily adopted by any application wanting to use TeleHash.
+Keeping a TeleHash Switch running takes some babysitting, all the timers to make sure Lines stay open, Dialing works, Listening is thorough, bandwidth usage is respected, and that peers are behaving appropriately.  Most applications need to have very careful control over their internal threading/event-handling models and the myriad of events needed to be a Switch adds a lot of complexity, so "switchd" is a simple localhost-based daemon that can do all that work in its own process space, and provide some simple local API calls that are much more easily adopted by any application wanting to use TeleHash.
 
 Goals:
 	- super lightweight daemon, like memcached


### PR DESCRIPTION
To disabiguate the two homophones, the possessive form
is spelled "its", without an appostrophe. The contraction
"it's" retains the appostrophe. A good way to check which
to write is to try replacing "it's" with the expansion "it is".
If that doesn't make sense, it's the possessive, and should
instead be "its".

I think I got all the "it's" which should be "its". I didn't check all of the reverse, but the code was using "it's" for both pretty consistently.
